### PR TITLE
fix: handle DiagnosticMessageChain in getProjectDiagnostics

### DIFF
--- a/packages/core/lib/checker.ts
+++ b/packages/core/lib/checker.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { DiagnosticCategory, Project } from "ts-morph";
+import { type DiagnosticMessageChain, DiagnosticCategory, Project, ts } from "ts-morph";
 
 export type Diagnostic = {
 	file: string;
@@ -60,6 +60,13 @@ function mapCategoryToSeverity(category: DiagnosticCategory): number {
 	}
 }
 
+function flattenMessageText(
+	msg: string | DiagnosticMessageChain,
+): string {
+	if (typeof msg === "string") return msg;
+	return ts.flattenDiagnosticMessageText(msg.compilerObject, "\n");
+}
+
 export function getProjectDiagnostics(
 	tsconfigPath: string,
 	filePath?: string,
@@ -94,7 +101,7 @@ export function getProjectDiagnostics(
 				file: fileDiagPath,
 				line: lineAndCol.line,
 				col: lineAndCol.column,
-				message: diagnostic.getMessageText().toString(),
+				message: flattenMessageText(diagnostic.getMessageText()),
 				code: diagnostic.getCode(),
 				severity: mapCategoryToSeverity(diagnostic.getCategory()),
 			});


### PR DESCRIPTION
## Summary

`getProjectDiagnostics` calls `diagnostic.getMessageText().toString()`, but ts-morph's `getMessageText()` returns `string | DiagnosticMessageChain`. When the diagnostic has nested messages (e.g. type assignability errors with "because..." chains), `toString()` on the `DiagnosticMessageChain` object produces `[object Object]` instead of the actual error text.

## Reproduction

```ts
import { Project, ts } from "ts-morph";

const p = new Project({ useInMemoryFileSystem: true, compilerOptions: { strict: true } });
p.createSourceFile("test.ts", `
type A = { x: string }
type B = { x: number }
const a: A = {} as B
`);

for (const d of p.getPreEmitDiagnostics()) {
  const msg = d.getMessageText();
  console.log("typeof:", typeof msg);           // "object"
  console.log(".toString():", msg.toString());   // "[object Object]"
}
```

## Fix

Use `ts.flattenDiagnosticMessageText()` to properly convert the chain into a readable multi-line string:

**Before:** `[object Object]`

**After:**
```
Type 'B' is not assignable to type 'A'.
  Types of property 'x' are incompatible.
    Type 'number' is not assignable to type 'string'.
```